### PR TITLE
zr / 課題2

### DIFF
--- a/kadai2/.gitignore
+++ b/kadai2/.gitignore
@@ -1,0 +1,2 @@
+exec
+testdata

--- a/kadai2/README.md
+++ b/kadai2/README.md
@@ -1,0 +1,81 @@
+# 仕様
+- ディレクトリを指定する
+- 指定したディレクトリ以下のJPGファイルをPNGに変換（デフォルト）
+- ディレクトリ以下は再帰的に処理する
+- 変換前と変換後の画像形式を指定できる（オプション）
+
+
+# 開発条件
+- テストのしやすさを考えてリファクタリングしてみる
+  - エラーハンドリングをリファクタ・makefileを追加
+- テストのカバレッジを取ってみる
+- テーブル駆動テストを行う
+- テストヘルパーを作ってみる
+  - `main_test.go`にてコマンドライン引数をセットするヘルパーを作成
+
+
+# オプション
+|オプション|説明|デフォルト|対応|
+|:---:|:---:|:---:|:---:|
+|-s|変換前の拡張子を指定|jpg|jpg・png|
+|-d|変換後の拡張子を指定|png|jpg・png|
+
+
+# 使い方
+```shell
+$ cd {Path_To_Repository}/kadai1
+$ ./testdata.zsh # テストデータ生成&初期化
+$ make build # ビルド
+$ make test # テスト
+```
+
+```shell
+$ # 単体ファイル(jpg->png)
+$ ./exec ./testdata/img/azarashi.jpg
+$ # 単体ファイル(png->jpg)
+$ ./exec -s png -d jpg ./testdata/img/osaru.png
+$ # ディレクトリ(jpg->png)
+$ ./exec ./testdata/img
+$ # ディレクトリ(png->jpg)
+$ ./exec -s png -d jpg ./testdata/img
+```
+
+
+# テストデータのディレクトリ構造
+```
+testdata
+├── err
+│   ├── read_permission
+│   ├── read_permission.jpg
+│   └── write_permission
+│       └── write_permission.jpg
+└── img
+    ├── azarashi.jpg
+    ├── tanuki.jpg
+    ├── osaru.png
+    └── img
+        ├── azarashi.jpg
+        └── tanuki.jpg
+```
+
+
+# io.Readerとio.Writerについて
+## 概要
+- データの入出力(読み書き)を抽象化するインターフェース
+- 標準パッケージでは`bytes.Buffer`、`os.File`、`image.Image`などで実装されている
+
+
+## 利点
+- 関数が外部の仕様を知りすぎない
+  - 例えばio.Readerを引数に持つ関数は、その引数がio.Readerを満たしていることだけ知っていればよく、その内部実装にまで依存しなくていい
+- 仕様変更に強い
+  - 読み込み元・書き込み先が変更になっても、その関数の実装の変更なしに、io.Reader/io.Writerを満たしている型と容易に付け替えられる
+- テスト時にモック・スタブを付け替えやすい
+
+
+## 参考
+- [io.Reader](https://golang.org/pkg/io/#Reader)
+- [io.Writer](https://golang.org/pkg/io/#Writer)
+- [bytes.Buffer](https://golang.org/pkg/bytes/#Buffer)
+- [os.File](https://golang.org/pkg/os/#File)
+- [image.Image](https://golang.org/pkg/image/#Image)

--- a/kadai2/go.mod
+++ b/kadai2/go.mod
@@ -1,0 +1,3 @@
+module github.com/gopherdojo/gopherdojo-studyroom/kadai2/komazz
+
+go 1.14

--- a/kadai2/imgconv/imgconv.go
+++ b/kadai2/imgconv/imgconv.go
@@ -1,7 +1,6 @@
 package imgconv
 
 import (
-	"fmt"
 	"image"
 	"image/jpeg"
 	"image/png"
@@ -23,8 +22,6 @@ var (
 		"jpg":  ".jpg",
 		"jpeg": ".jpg",
 	}
-	errDecodeFailed = fmt.Errorf("Decode Fail Error")
-	errEncodeFailed = fmt.Errorf("Encode Fail Error")
 )
 
 // ValidExt サポートされている拡張子か確認する関数
@@ -97,30 +94,26 @@ func (c *Converter) Convert(src string) error {
 // Decode 画像をデコードする関数
 func (c *Converter) Decode(srcfile io.Reader) (image.Image, error) {
 	var img image.Image
+	var err error
 	switch c.SrcExt {
 	case ".jpg":
-		img, err := jpeg.Decode(srcfile)
-		return img, err
+		img, err = jpeg.Decode(srcfile)
 	case ".png":
-		img, err := png.Decode(srcfile)
-		return img, err
-	default:
-		return img, errDecodeFailed
+		img, err = png.Decode(srcfile)
 	}
+	return img, err
 }
 
 // Encode 画像をエンコードする関数
 func (c *Converter) Encode(dstfile io.Writer, img image.Image) error {
+	var err error
 	switch c.DstExt {
 	case ".png":
-		err := png.Encode(dstfile, img)
-		return err
+		err = png.Encode(dstfile, img)
 	case ".jpg":
-		err := jpeg.Encode(dstfile, img, &jpeg.Options{Quality: jpeg.DefaultQuality})
-		return err
-	default:
-		return errEncodeFailed
+		err = jpeg.Encode(dstfile, img, &jpeg.Options{Quality: jpeg.DefaultQuality})
 	}
+	return err
 }
 
 // createDstFileName 画像の出力先ファイル名を作成する関数

--- a/kadai2/imgconv/imgconv.go
+++ b/kadai2/imgconv/imgconv.go
@@ -1,0 +1,132 @@
+package imgconv
+
+import (
+	"fmt"
+	"image"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Converter 画像の拡張子変換を行う型
+type Converter struct {
+	SrcExt string
+	DstExt string
+}
+
+var (
+	supportExt = map[string]string{
+		"png":  ".png",
+		"jpg":  ".jpg",
+		"jpeg": ".jpg",
+	}
+	errDecodeFailed = fmt.Errorf("Decode Fail Error")
+	errEncodeFailed = fmt.Errorf("Encode Fail Error")
+)
+
+// ValidExt サポートされている拡張子か確認する関数
+func ValidExt(ext string) bool {
+	_, ok := supportExt[ext]
+	return ok
+}
+
+// NewConverter Converter型を生成する関数
+func NewConverter(srcExt, dstExt string) *Converter {
+	return &Converter{
+		SrcExt: supportExt[srcExt],
+		DstExt: supportExt[dstExt],
+	}
+}
+
+// SrcFileList 変換する候補のファイルを再帰取得する関数
+func (c *Converter) SrcFileList(srcPath string) ([]string, error) {
+	var srcFileList []string
+	err := filepath.Walk(srcPath, func(path string, info os.FileInfo, err error) error {
+		if filepath.Ext(path) == c.SrcExt {
+			srcFileList = append(srcFileList, path)
+		}
+		return nil
+	})
+	return srcFileList, err
+}
+
+// Convert 画像の拡張子変換をするメインロジック関数
+func (c *Converter) Convert(src string) error {
+	// 入力ファイルを取得する
+	srcfile, err := os.Open(filepath.Clean(src))
+	if err != nil {
+		return err
+	}
+	defer func() error {
+		if err := srcfile.Close(); err != nil {
+			return err
+		}
+		return nil
+	}()
+
+	// 読み出す(decode)
+	img, err := c.Decode(srcfile)
+	if err != nil {
+		return err
+	}
+
+	// 出力ファイルを作成する
+	dst := c.createDstFileName(src)
+	dstfile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() error {
+		if err := dstfile.Close(); err != nil {
+			return err
+		}
+		return nil
+	}()
+
+	// 書き出す(encode)
+	err = c.Encode(dstfile, img)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Decode 画像をデコードする関数
+func (c *Converter) Decode(srcfile io.Reader) (image.Image, error) {
+	var img image.Image
+	switch c.SrcExt {
+	case ".jpg":
+		img, err := jpeg.Decode(srcfile)
+		return img, err
+	case ".png":
+		img, err := png.Decode(srcfile)
+		return img, err
+	default:
+		return img, errDecodeFailed
+	}
+}
+
+// Encode 画像をエンコードする関数
+func (c *Converter) Encode(dstfile io.Writer, img image.Image) error {
+	switch c.DstExt {
+	case ".png":
+		err := png.Encode(dstfile, img)
+		return err
+	case ".jpg":
+		err := jpeg.Encode(dstfile, img, &jpeg.Options{Quality: jpeg.DefaultQuality})
+		return err
+	default:
+		return errEncodeFailed
+	}
+}
+
+// createDstFileName 画像の出力先ファイル名を作成する関数
+func (c *Converter) createDstFileName(src string) string {
+	oldExt := filepath.Ext(src)
+	newExt := c.DstExt
+	dst := strings.Replace(src, oldExt, newExt, 1)
+	return dst
+}

--- a/kadai2/imgconv/imgconv.go
+++ b/kadai2/imgconv/imgconv.go
@@ -51,17 +51,16 @@ func (c *Converter) SrcFileList(srcPath string) ([]string, error) {
 }
 
 // Convert 画像の拡張子変換をするメインロジック関数
-func (c *Converter) Convert(src string) error {
+func (c *Converter) Convert(src string) (err error) {
 	// 入力ファイルを取得する
 	srcfile, err := os.Open(filepath.Clean(src))
 	if err != nil {
 		return err
 	}
-	defer func() error {
-		if err := srcfile.Close(); err != nil {
-			return err
+	defer func() {
+		if cerr := srcfile.Close(); cerr != nil {
+			err = cerr
 		}
-		return nil
 	}()
 
 	// 読み出す(decode)
@@ -76,11 +75,10 @@ func (c *Converter) Convert(src string) error {
 	if err != nil {
 		return err
 	}
-	defer func() error {
-		if err := dstfile.Close(); err != nil {
-			return err
+	defer func() {
+		if cerr := dstfile.Close(); cerr != nil {
+			err = cerr
 		}
-		return nil
 	}()
 
 	// 書き出す(encode)

--- a/kadai2/imgconv/imgconv_test.go
+++ b/kadai2/imgconv/imgconv_test.go
@@ -1,0 +1,135 @@
+package imgconv
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+var (
+	testDir    = "../testdata/img"
+	testDirErr = "../testdata/err"
+)
+
+func TestValidExt(t *testing.T) {
+	tests := []struct {
+		name    string
+		ext     string
+		isValid bool
+	}{
+		// 異常系
+		{
+			name:    "gif",
+			ext:     "gif",
+			isValid: false,
+		},
+
+		// 正常系
+		{
+			name:    "png",
+			ext:     "png",
+			isValid: true,
+		},
+		{
+			name:    "jpg",
+			ext:     "jpg",
+			isValid: true,
+		},
+		{
+			name:    "jpeg",
+			ext:     "jpeg",
+			isValid: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			valid := ValidExt(tt.ext)
+			if valid != tt.isValid {
+				t.Errorf("Expected %t, Got %t", tt.isValid, valid)
+			}
+		})
+	}
+}
+
+func TestSrcFileList(t *testing.T) {
+	tests := []struct {
+		name      string
+		converter Converter
+		src       string
+		isErr     bool
+	}{
+		// 異常系
+		{
+			name:      "Error: get jpg file list",
+			converter: *NewConverter("jpg", "png"),
+			src:       filepath.Join(testDirErr, "read_permission"),
+			isErr:     true,
+		},
+
+		// 正常系
+		{
+			name:      "Success: get jpg file list",
+			converter: *NewConverter("jpg", "png"),
+			src:       testDir,
+			isErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := tt.converter
+			_, err := c.SrcFileList(tt.src)
+			if !tt.isErr && err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func TestConvert(t *testing.T) {
+	tests := []struct {
+		name      string
+		converter Converter
+		src       string
+		isErr     bool
+	}{
+		// 異常系
+		{
+			name:      "Error: Fail to Read",
+			converter: *NewConverter("jpg", "png"),
+			src:       filepath.Join(testDirErr, "read_permission.jpg"),
+			isErr:     true,
+		},
+		{
+			name:      "Error: Fail to Write",
+			converter: *NewConverter("jpg", "png"),
+			src:       filepath.Join(testDirErr, "write_permission/write_permission.jpg"),
+			isErr:     true,
+		},
+
+		// 正常系
+		{
+			name:      "Success: File: jpg → png",
+			converter: *NewConverter("jpg", "png"),
+			src:       filepath.Join(testDir, "azarashi.jpg"),
+			isErr:     false,
+		},
+		{
+			name:      "Success: File: png → png",
+			converter: *NewConverter("png", "jpg"),
+			src:       filepath.Join(testDir, "osaru.png"),
+			isErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := tt.converter
+			err := c.Convert(tt.src)
+			if !tt.isErr && err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/kadai2/main.go
+++ b/kadai2/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gopherdojo/gopherdojo-studyroom/kadai2/komazz/imgconv"
+)
+
+var (
+	srcExt, dstExt          string
+	errTooFewArgument       = fmt.Errorf("Too Few Arguments")
+	errUnsupportedExtension = fmt.Errorf("Unsupported extension")
+)
+
+func init() {
+	flag.StringVar(&srcExt, "s", "jpg", "Optional: Extension of Source Image.")
+	flag.StringVar(&dstExt, "d", "png", "Optional: Extension of Destination Image.")
+	flag.Parse()
+}
+
+func exec() error {
+	args := flag.Args()
+	if len(args) < 1 {
+		return errTooFewArgument
+	}
+
+	if !imgconv.ValidExt(srcExt) || !imgconv.ValidExt(dstExt) {
+		return errUnsupportedExtension
+	}
+
+	c := imgconv.NewConverter(srcExt, dstExt)
+
+	srcPath := args[0]
+	dir, err := os.Stat(srcPath)
+	if err != nil {
+		return err
+	}
+
+	if dir.IsDir() {
+		// ディレクトリ指定の場合
+		fileList, err := c.SrcFileList(srcPath)
+		if err != nil {
+			return err
+		}
+		for _, src := range fileList {
+			if err := c.Convert(src); err != nil {
+				return err
+			}
+		}
+	} else {
+		// ファイル指定の場合
+		if filepath.Ext(srcPath) != c.SrcExt {
+			return errUnsupportedExtension
+		}
+		if err := c.Convert(srcPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	if err := exec(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
+	}
+}

--- a/kadai2/main.go
+++ b/kadai2/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -11,8 +12,8 @@ import (
 
 var (
 	srcExt, dstExt          string
-	errTooFewArgument       = fmt.Errorf("Too Few Arguments")
-	errUnsupportedExtension = fmt.Errorf("Unsupported extension")
+	errTooFewArgument       = errors.New("Too Few Arguments")
+	errUnsupportedExtension = errors.New("Unsupported extension")
 )
 
 func init() {

--- a/kadai2/main.go
+++ b/kadai2/main.go
@@ -18,10 +18,10 @@ var (
 func init() {
 	flag.StringVar(&srcExt, "s", "jpg", "Optional: Extension of Source Image.")
 	flag.StringVar(&dstExt, "d", "png", "Optional: Extension of Destination Image.")
-	flag.Parse()
 }
 
 func exec() error {
+	flag.Parse()
 	args := flag.Args()
 	if len(args) < 1 {
 		return errTooFewArgument

--- a/kadai2/main_test.go
+++ b/kadai2/main_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type args struct {
+	src string
+	dst string
+}
+
+var (
+	testDir         = "testdata/img"
+	testDirInvalid  = "testdataa"
+	testfileJPG     = "azarashi.jpg"
+	testfilePNG     = "osaru.png"
+	testfileInvalid = "hito.jpg"
+)
+
+func TestExec(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  args
+		src   string
+		isErr bool
+	}{
+		// 異常系
+		{
+			name: "Error: TooFewArguments",
+			args: args{
+				src: "",
+				dst: "",
+			},
+			src:   "",
+			isErr: true,
+		},
+		{
+			name: "Error: File: UnsupportedExtension",
+			args: args{
+				src: "",
+				dst: "",
+			},
+			src:   filepath.Join(testDir, testfilePNG),
+			isErr: true,
+		},
+		{
+			name: "Error: Dir: UnkownDirectory",
+			args: args{
+				src: "",
+				dst: "",
+			},
+			src:   testDirInvalid,
+			isErr: true,
+		},
+		{
+			name: "Error: Dir: UnsupportedExtension",
+			args: args{
+				src: "png",
+				dst: "pdf",
+			},
+			src:   filepath.Join(testDir, testfileInvalid),
+			isErr: true,
+		},
+		{
+			name: "Error: File: Fail to Convert",
+			args: args{
+				src: "png",
+				dst: "pdf",
+			},
+			src:   filepath.Join(testDir, testfileJPG),
+			isErr: true,
+		},
+		// 正常系
+		{
+			name: "Success: File: jpg → png",
+			args: args{
+				src: "jpg",
+				dst: "png",
+			},
+			src:   filepath.Join(testDir, testfileJPG),
+			isErr: false,
+		},
+		{
+			name: "Success: File: png → jpg",
+			args: args{
+				src: "png",
+				dst: "jpg",
+			},
+			src:   filepath.Join(testDir, testfilePNG),
+			isErr: false,
+		},
+		{
+			name: "Success: Dir: png → jpg",
+			args: args{
+				src: "png",
+				dst: "jpg",
+			},
+			src:   testDir,
+			isErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := setFlag(t, tt.src, tt.args)
+			if err != nil {
+				t.Error(err)
+			}
+
+			err = exec()
+			if !tt.isErr && err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+// setFlag コマンドライン引数をセットする
+func setFlag(t *testing.T, src string, args args) error {
+	t.Helper()
+
+	// set non-flag
+	if src != "" {
+		os.Args[1] = src
+	}
+
+	// set flag(s)
+	if args.src != "" {
+		err := flag.CommandLine.Set("s", args.src)
+		if err != nil {
+			return err
+		}
+	}
+
+	// set flag(d)
+	if args.dst != "" {
+		err := flag.CommandLine.Set("d", args.dst)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/kadai2/makefile
+++ b/kadai2/makefile
@@ -1,0 +1,16 @@
+.PHONY: build
+build:
+	@sh -c "go build -o ./exec"
+
+.PHONY: gosec
+gosec:
+	@sh -c "gosec ./..."
+
+.PHONY: golint
+golint:
+	@sh -c "golint ./..."
+
+.PHONY: test
+test:
+	@sh -c "./testdata.zsh"
+	@sh -c "go test -cover ./..."

--- a/kadai2/testdata.zsh
+++ b/kadai2/testdata.zsh
@@ -1,0 +1,14 @@
+#!/bin/zsh
+
+rm -r testdata
+
+mkdir testdata
+mkdir testdata/img
+
+curl http://flat-icon-design.com/f/f_object_174/s512_f_object_174_0bg.jpg > ./testdata/azarashi.jpg
+curl http://flat-icon-design.com/f/f_object_174/s512_f_object_174_0bg.jpg > ./testdata/img/azarashi.jpg
+
+curl http://flat-icon-design.com/f/f_object_149/s512_f_object_149_0bg.jpg > ./testdata/tanuki.jpg
+curl http://flat-icon-design.com/f/f_object_149/s512_f_object_149_0bg.jpg > ./testdata/img/tanuki.jpg
+
+curl http://flat-icon-design.com/f/f_object_157/s512_f_object_157_0bg.png > ./testdata/osaru.png

--- a/kadai2/testdata.zsh
+++ b/kadai2/testdata.zsh
@@ -1,14 +1,31 @@
 #!/bin/zsh
 
+if [ -e ./testdata ];then
+chmod -R 755 ./testdata
+fi
 rm -r testdata
-
 mkdir testdata
+
+# 正常系
 mkdir testdata/img
+mkdir testdata/img/img
 
-curl http://flat-icon-design.com/f/f_object_174/s512_f_object_174_0bg.jpg > ./testdata/azarashi.jpg
 curl http://flat-icon-design.com/f/f_object_174/s512_f_object_174_0bg.jpg > ./testdata/img/azarashi.jpg
-
-curl http://flat-icon-design.com/f/f_object_149/s512_f_object_149_0bg.jpg > ./testdata/tanuki.jpg
+curl http://flat-icon-design.com/f/f_object_174/s512_f_object_174_0bg.jpg > ./testdata/img/img/azarashi.jpg
 curl http://flat-icon-design.com/f/f_object_149/s512_f_object_149_0bg.jpg > ./testdata/img/tanuki.jpg
+curl http://flat-icon-design.com/f/f_object_149/s512_f_object_149_0bg.jpg > ./testdata/img/img/tanuki.jpg
+curl http://flat-icon-design.com/f/f_object_157/s512_f_object_157_0bg.png > ./testdata/img/osaru.png
 
-curl http://flat-icon-design.com/f/f_object_157/s512_f_object_157_0bg.png > ./testdata/osaru.png
+
+# 異常系
+mkdir testdata/err
+
+mkdir testdata/err/read_permission
+curl http://flat-icon-design.com/f/f_object_149/s512_f_object_149_0bg.jpg > ./testdata/err/read_permission.jpg
+chmod 355 ./testdata/err/read_permission
+chmod 355 ./testdata/err/read_permission.jpg
+
+mkdir testdata/err/write_permission
+curl http://flat-icon-design.com/f/f_object_149/s512_f_object_149_0bg.jpg > ./testdata/err/write_permission/write_permission.jpg
+chmod 555 ./testdata/err/write_permission
+chmod 555 ./testdata/err/write_permission/write_permission.jpg


### PR DESCRIPTION
# 仕様・オプション・io.Readerとio.Writerについて
- READMEを参照

# テストカバレッジ
```shell
github.com/gopherdojo/gopherdojo-studyroom/kadai2/komazz
coverage: 78.6% of statements
github.com/gopherdojo/gopherdojo-studyroom/kadai2/komazz/imgconv
coverage: 91.3% of statements
```

# 動作確認方法
```shell
$ cd {Path_To_Repository}/kadai2
$ make test # テスト
```

# その他
## 工夫した点
- makefileを作成
- 並行にやってもデータ競合しないテストは`t.Parallel()`を使用

### 疑問に思った点
- テストの順番によって、テストの結果が変わったことがあった
  - コマンドライン引数をセットしない異常系のテストで、前のテストでセットした引数が使われていた
    - この異常系を先にテストすることで、予期しない値でテストするのを防いでいる
    - 毎回フラグをリセットするやり方があればリファクタしたい
- テストのファイルの名前管理(一部varで定義している)をもっとDRYにやりたい
- カバレッジをあげようとすると、単体テストと複合テストで同じような実装のテストをしていることに気づいたが、これはこれでいいのか
  - mainのテストというよりかは、読み込みパッケージの方にロジックを全て寄せればよかった
